### PR TITLE
csv export: use RFC 3339 format for timestamps

### DIFF
--- a/app/src/main/java/app/traced_it/ui/entry/EntryViewModel.kt
+++ b/app/src/main/java/app/traced_it/ui/entry/EntryViewModel.kt
@@ -56,7 +56,7 @@ class EntryViewModel @Inject constructor(
     }
 
     @Suppress("SpellCheckingInspection")
-    private val csvDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
+    private val csvDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US)
 
     private val _message = MutableStateFlow<Message?>(null)
     val message: StateFlow<Message?> = _message


### PR DESCRIPTION
The difference is the use of the colon in the offset; e.g. `-8:00` instead of `-800`.  Both versions are valid iso8601 but I was trying to parse with clojure.instant which expects RFC 3339 only.